### PR TITLE
Taking Content-Encoding into account in isByteRequest

### DIFF
--- a/dist/utils/request.js
+++ b/dist/utils/request.js
@@ -29,10 +29,11 @@ const prefixContentTypes = new Set([
  * @returns {boolean} - Returns true if the request is for binary data, otherwise false.
  */
 function isByteRequest(headers) {
-    if (headers["content-encoding"])
+    if (headers["content-encoding"] || headers["Content-Encoding"])
         return true;
-    const contentType = headers["content-type"];
-    const contentTransferEncoding = headers["content-transfer-encoding"];
+    const contentType = headers["content-type"] || headers["Content-Type"];
+    const contentTransferEncoding = headers["content-transfer-encoding"] ||
+        headers["Content-Transfer-Encoding"];
     if (contentTransferEncoding) {
         const encodingString = String(contentTransferEncoding);
         if (exactContentTypes.has(encodingString)) {

--- a/dist/utils/request.js
+++ b/dist/utils/request.js
@@ -21,7 +21,7 @@ const prefixContentTypes = new Set([
 /**
  * Determines if a request should be treated as a byte request based on its headers.
  *
- * This function checks the "Content-Type" and "Content-Transfer-Encoding" headers
+ * This function checks the "Content-Encoding", "Content-Type" and "Content-Transfer-Encoding" headers
  * to determine if the request is for binary data (such as images, audio, video,
  * application binaries, etc.). If the headers indicate binary data, it returns true.
  *
@@ -29,9 +29,10 @@ const prefixContentTypes = new Set([
  * @returns {boolean} - Returns true if the request is for binary data, otherwise false.
  */
 function isByteRequest(headers) {
-    const contentType = headers["content-type"] || headers["Content-Type"];
-    const contentTransferEncoding = headers["content-transfer-encoding"] ||
-        headers["Content-Transfer-Encoding"];
+    if (headers["content-encoding"])
+        return true;
+    const contentType = headers["content-type"];
+    const contentTransferEncoding = headers["content-transfer-encoding"];
     if (contentTransferEncoding) {
         const encodingString = String(contentTransferEncoding);
         if (exactContentTypes.has(encodingString)) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "cloudflare"
   ],
   "devDependencies": {
-    "@types/node": "^20.12.12",
+    "@types/node": "^20.17.30",
     "@types/tough-cookie": "^4.0.5",
     "typedoc": "^0.25.13",
     "typescript": "^5.4.5"

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -30,10 +30,12 @@ const prefixContentTypes = new Set([
  * @returns {boolean} - Returns true if the request is for binary data, otherwise false.
  */
 export function isByteRequest(headers: OutgoingHttpHeaders): boolean {
-  if (headers["content-encoding"]) return true;
+  if (headers["content-encoding"] || headers["Content-Encoding"]) return true;
 
-  const contentType = headers["content-type"];
-  const contentTransferEncoding = headers["content-transfer-encoding"];
+  const contentType = headers["content-type"] || headers["Content-Type"];
+  const contentTransferEncoding =
+    headers["content-transfer-encoding"] ||
+    headers["Content-Transfer-Encoding"];
 
   if (contentTransferEncoding) {
     const encodingString = String(contentTransferEncoding);

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -22,7 +22,7 @@ const prefixContentTypes = new Set([
 /**
  * Determines if a request should be treated as a byte request based on its headers.
  *
- * This function checks the "Content-Type" and "Content-Transfer-Encoding" headers
+ * This function checks the "Content-Encoding", "Content-Type" and "Content-Transfer-Encoding" headers
  * to determine if the request is for binary data (such as images, audio, video,
  * application binaries, etc.). If the headers indicate binary data, it returns true.
  *
@@ -30,10 +30,10 @@ const prefixContentTypes = new Set([
  * @returns {boolean} - Returns true if the request is for binary data, otherwise false.
  */
 export function isByteRequest(headers: OutgoingHttpHeaders): boolean {
-  const contentType = headers["content-type"] || headers["Content-Type"];
-  const contentTransferEncoding =
-    headers["content-transfer-encoding"] ||
-    headers["Content-Transfer-Encoding"];
+  if (headers["content-encoding"]) return true;
+
+  const contentType = headers["content-type"];
+  const contentTransferEncoding = headers["content-transfer-encoding"];
 
   if (contentTransferEncoding) {
     const encodingString = String(contentTransferEncoding);

--- a/typings/utils/request.d.ts
+++ b/typings/utils/request.d.ts
@@ -3,7 +3,7 @@ import { OutgoingHttpHeaders } from "http";
 /**
  * Determines if a request should be treated as a byte request based on its headers.
  *
- * This function checks the "Content-Type" and "Content-Transfer-Encoding" headers
+ * This function checks the "Content-Encoding", "Content-Type" and "Content-Transfer-Encoding" headers
  * to determine if the request is for binary data (such as images, audio, video,
  * application binaries, etc.). If the headers indicate binary data, it returns true.
  *


### PR DESCRIPTION
This commit updates the isByteRequest function to return true in-case Content-Encoding header is set to a non-empty value. This is because encoded content is always in bytes.